### PR TITLE
Select all e2e

### DIFF
--- a/example/select-all/claims/clusters-claims.yaml
+++ b/example/select-all/claims/clusters-claims.yaml
@@ -1,0 +1,31 @@
+apiVersion: example.crossplane.io/v1
+kind: Cluster
+metadata:
+  name: cluster-1
+  labels:
+    environment: staging
+spec: {}
+---
+apiVersion: example.crossplane.io/v1
+kind: Cluster
+metadata:
+  name: cluster-2
+  labels:
+    environment: production
+spec: {}
+---
+apiVersion: example.crossplane.io/v1
+kind: Cluster
+metadata:
+  name: cluster-3
+  labels:
+    environment: staging
+spec: {}
+---
+apiVersion: example.crossplane.io/v1
+kind: Cluster
+metadata:
+  name: cluster-4
+  labels:
+    environment: production
+spec: {}

--- a/example/select-all/claims/manager-claims.yaml
+++ b/example/select-all/claims/manager-claims.yaml
@@ -1,0 +1,5 @@
+apiVersion: example.crossplane.io/v1
+kind: Manager
+metadata:
+  name: manager-singleton
+spec: {}

--- a/example/select-all/compositions/managers-composition-v1.yaml
+++ b/example/select-all/compositions/managers-composition-v1.yaml
@@ -1,0 +1,53 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: networkmanager-composition
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XManager
+  mode: Pipeline
+  pipeline:
+  - step: fetch-clusters
+    functionRef:
+      name: function-extra-resources-with-select-all
+    input:
+      apiVersion: extra-resources.fn.yzdann.io/v1beta1
+      kind: Input
+      spec:
+        extraResources:
+          - kind: Cluster
+            into: AllClusters
+            apiVersion: example.crossplane.io/v1
+            type: Selector
+            selector: {}
+  - step: create-networks
+    functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      kind: GoTemplate
+      source: Inline
+      inline:
+        template: |
+          {{- $clusters := index (index .context "apiextensions.crossplane.io/extra-resources") "AllClusters" }}
+          {{- range $i, $cluster := $clusters }}
+          ---
+          apiVersion: kubernetes.crossplane.io/v1alpha2
+          kind: Object
+          metadata:
+            name: {{ index (index $cluster "metadata") "name" }}-networkmanager
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: {{ printf "networkmanager-%d" $i }}
+          spec:
+            forProvider:
+              manifest:
+                apiVersion: example.crossplane.io/v1
+                kind: Network
+                metadata:
+                  name: {{ index (index $cluster "metadata") "name" }}-networkmanager
+                  namespace: default
+                spec: {}
+            providerConfigRef:
+              name: kubernetes
+          {{- end }}

--- a/example/select-all/compositions/managers-composition-v2.yaml
+++ b/example/select-all/compositions/managers-composition-v2.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: networkmanager-composition
+spec:
+  compositeTypeRef:
+    apiVersion: example.crossplane.io/v1
+    kind: XManager
+  mode: Pipeline
+  pipeline:
+  - step: fetch-clusters
+    functionRef:
+      name: function-extra-resources-with-select-all
+    input:
+      apiVersion: extra-resources.fn.yzdann.io/v1beta1
+      kind: Input
+      spec:
+        extraResources:
+          - kind: Cluster
+            into: AllClusters
+            apiVersion: example.crossplane.io/v1
+            type: Selector
+            selector: {}
+  - step: create-networks
+    functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      kind: GoTemplate
+      source: Inline
+      inline:
+        template: |
+          {{- $clusters := index (index .context "apiextensions.crossplane.io/extra-resources") "AllClusters" }}
+          {{- range $i, $cluster := $clusters }}
+          ---
+          apiVersion: example.crossplane.io/v1
+          kind: Network
+          metadata:
+            namespace: default
+            name: {{ index (index $cluster "metadata") "name" }}-networkmanager
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: {{ printf "networkmanager-%d" $i }}
+          spec: {}
+          {{- end }}

--- a/example/select-all/functions/fn.yaml
+++ b/example/select-all/functions/fn.yaml
@@ -1,0 +1,25 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-extra-resources-with-select-all
+  namespace: crossplane-system
+spec:
+  package: ttl.sh/yzdann/function-extra-resources-with-select-all:3h
+  packagePullPolicy: Always
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-extra-resources
+  namespace: crossplane-system
+spec:
+# package: ttl.sh/function-e-r-v2:3h
+  package: xpkg.upbound.io/crossplane-contrib/function-extra-resources:v0.0.3
+  packagePullPolicy: Always
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-go-templating
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.8.0

--- a/example/select-all/provider-config/providerconfig.yaml
+++ b/example/select-all/provider-config/providerconfig.yaml
@@ -1,0 +1,9 @@
+# Source: providers/templates/provider.kubernetes.yaml
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: kubernetes
+  labels:
+spec:
+  credentials:
+    source: InjectedIdentity

--- a/example/select-all/provider/clustersrolebinding.yaml
+++ b/example/select-all/provider/clustersrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: provider-kubernetes-cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: provider-kubernetes
+    namespace: crossplane-system
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/example/select-all/provider/deploymentruntimeconfig.yaml
+++ b/example/select-all/provider/deploymentruntimeconfig.yaml
@@ -1,0 +1,12 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
+metadata:
+  name: provider-kubernetes
+  labels:
+spec:
+  deploymentTemplate:
+    metadata:
+      labels:
+  serviceAccountTemplate:
+    metadata:
+      name: provider-kubernetes

--- a/example/select-all/provider/provider.yaml
+++ b/example/select-all/provider/provider.yaml
@@ -1,0 +1,10 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-kubernetes
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.14.1
+  runtimeConfigRef:
+    apiVersion: pkg.crossplane.io/v1beta1
+    kind: DeploymentRuntimeConfig
+    name: provider-kubernetes

--- a/example/select-all/xrds/clusters-xrd.yaml
+++ b/example/select-all/xrds/clusters-xrd.yaml
@@ -1,0 +1,25 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xclusters.example.crossplane.io
+spec:
+  group: example.crossplane.io
+  names:
+    kind: XCluster
+    plural: xclusters
+  claimNames:
+    kind: Cluster
+    plural: clusters
+  versions:
+  - name: v1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties: {}
+          status:
+            type: object

--- a/example/select-all/xrds/managers-xrd.yaml
+++ b/example/select-all/xrds/managers-xrd.yaml
@@ -1,0 +1,25 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xmanagers.example.crossplane.io
+spec:
+  group: example.crossplane.io
+  names:
+    kind: XManager
+    plural: xmanagers
+  claimNames:
+    kind: Manager
+    plural: managers
+  versions:
+  - name: v1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties: {}
+          status:
+            type: object

--- a/example/select-all/xrds/networks-xrd.yaml
+++ b/example/select-all/xrds/networks-xrd.yaml
@@ -1,0 +1,25 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xnetworks.example.crossplane.io
+spec:
+  group: example.crossplane.io
+  names:
+    kind: XNetwork
+    plural: xnetworks
+  claimNames:
+    kind: Network
+    plural: networks
+  versions:
+  - name: v1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties: {}
+          status:
+            type: object

--- a/fn.go
+++ b/fn.go
@@ -153,9 +153,10 @@ func buildRequirements(in *v1beta1.Input, xr *resource.Composite) (*fnv1.Require
 					matchLabels[selector.Key] = value
 				}
 			}
-			if len(matchLabels) == 0 {
-				continue
-			}
+			// Allow select all!
+			// if len(matchLabels) == 0 {
+			//	continue
+			// }
 			extraResources[extraResName] = &fnv1.ResourceSelector{
 				ApiVersion: extraResource.APIVersion,
 				Kind:       extraResource.Kind,

--- a/input/v1beta1/input.go
+++ b/input/v1beta1/input.go
@@ -1,6 +1,6 @@
 // Package v1beta1 contains the input type for this Function
 // +kubebuilder:object:generate=true
-// +groupName=extra-resources.fn.crossplane.io
+// +groupName=extra-resources.fn.yzdann.io
 // +versionName=v1beta1
 package v1beta1
 

--- a/package/input/extra-resources.fn.yzdann.io_inputs.yaml
+++ b/package/input/extra-resources.fn.yzdann.io_inputs.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.0
-  name: inputs.extra-resources.fn.crossplane.io
+  name: inputs.extra-resources.fn.yzdann.io
 spec:
-  group: extra-resources.fn.crossplane.io
+  group: extra-resources.fn.yzdann.io
   names:
     categories:
     - crossplane


### PR DESCRIPTION
Building the function image:
```
 go generate ./...

docker build . --platform=linux/amd64 --tag runtime-amd64

docker save runtime-amd64 -o runtime-amd64.tar

crossplane xpkg build --package-root=package --embed-runtime-image-tarball=runtime-amd64.tar --package-file=function-amd64.xpkg


crossplane xpkg push -f function-amd64.xpkg ttl.sh/yzdann/function-extra-resources-with-select-all:3h
```


```
# creating a cluster
kind create cluster 
 
# installing crossplane v2
helm install crossplane \
--namespace crossplane-system \
--create-namespace crossplane-stable/crossplane --version=2.0.0

# having three types, the manager is a singleton
kubectl apply -f ./example/select-all/xrds
Warning: CompositeResourceDefinition v1 is deprecated and will be removed in a future release; consider migrating to v2
compositeresourcedefinition.apiextensions.crossplane.io/xclusters.example.crossplane.io created
compositeresourcedefinition.apiextensions.crossplane.io/xmanagers.example.crossplane.io created
compositeresourcedefinition.apiextensions.crossplane.io/xnetworks.example.crossplane.io created

# installing our function extra resources and go template that I used in composition
kubectl apply -f ./example/select-all/functions/


#  creates four clusters, and the manager
kubectl apply -f ./example/select-all/claims/

# this is composition for manager, that fetches all the clusters and then creates simply one network per cluster
kubectl apply -f ./example/select-all/compositions/managers-composition-v2.yaml
```

Result:
```
kubectl get networks -A
k get networks -A
NAMESPACE   NAME                       SYNCED   READY   CONNECTION-SECRET   AGE
default     cluster-1-networkmanager   True     False                       14m
default     cluster-2-networkmanager   True     False                       14m
default     cluster-3-networkmanager   True     False                       14m
default     cluster-4-networkmanager   True     False                       14m


```
